### PR TITLE
Add OpenShift 4.9 to the list of supported orchestrators

### DIFF
--- a/trident-get-started/requirements.adoc
+++ b/trident-get-started/requirements.adoc
@@ -20,12 +20,12 @@ Astra Trident supports multiple container engines and orchestrators, including t
 
 * Kubernetes 1.17 or later (latest: 1.22)
 * Mirantis Kubernetes Engine 3.4
-* OpenShift 4.4, 4.5, 4.6 (4.6.8+), 4.7, 4.8 (latest 4.8)
+* OpenShift 4.4, 4.5, 4.6 (4.6.8+), 4.7, 4.8, 4.9 (latest 4.9)
 
 The Trident operator is supported with these releases:
 
 * Kubernetes 1.17 or later (latest: 1.22)
-* OpenShift 4.4, 4.5, 4.6 (4.6.8+), 4.7, 4.8 (latest 4.8)
+* OpenShift 4.4, 4.5, 4.6 (4.6.8+), 4.7, 4.8, 4.9 (latest 4.9)
 
 NOTE: Red Hat OpenShift Container Platform users might observe their initiatorname.iscsi file to be blank if using any version below 4.6.8. This is a bug that has been identified by RedHat to be fixed with OpenShift 4.6.8. See this https://access.redhat.com/errata/RHSA-2020:5259/[bug fix announcement^]. NetApp recommends that you use Astra Trident on OpenShift 4.6.8 and later.
 


### PR DESCRIPTION
Per issue #31 