### PR TITLE
Update requirements.adoc

### DIFF
--- a/trident-get-started/requirements.adoc
+++ b/trident-get-started/requirements.adoc
@@ -116,7 +116,7 @@ Astra Trident might require some changes to a storage system before a backend co
 
 == Container images and corresponding Kubernetes versions
 
-For air-gapped installations, see the following list for what container images are needed to install Astra Trident:
+For air-gapped installations, the following list is a reference of container images needed to install Astra Trident. Use the `tridentctl images` command to verify the list of needed container images. 
 
 [cols=2,options="header"]
 |===


### PR DESCRIPTION
We received a PR (https://github.com/NetApp/trident/pull/626) to correct the Trident version in the container image list for a patch release. It doesn't seem to be the right thing to do to include a version of this table for every Trident patch release. @juliantap, I instead added instructions to run the tridentctl command to get the correct list of container images for that version of Trident. Let me know what you think.