### PR TITLE
Tweak to collapsible blocks heading

### DIFF
--- a/trident-use/ads.adoc
+++ b/trident-use/ads.adoc
@@ -82,7 +82,7 @@ NOTE: For all volumes created on an ADS backend, Astra Trident will copy all the
 This is the absolute minimum backend configuration.
 
 // Start snippet: collapsible block (open on page load)
-.Expand example
+.Example
 [%collapsible]
 ====
 
@@ -105,7 +105,7 @@ This is the absolute minimum backend configuration.
 This example shows a backend file that applies the same aspects to all Astra Trident-created storage.
 
 // Start snippet: collapsible block (open on page load)
-.Expand example
+.Example
 [%collapsible]
 ====
 
@@ -133,7 +133,7 @@ This example shows a backend file that applies the same aspects to all Astra Tri
 This example shows the backend definition file configured with virtual storage pools along with StorageClasses that refer back to them.
 
 // Start snippet: collapsible block (open on page load)
-.Expand example
+.Example
 [%collapsible]
 ====
 
@@ -177,7 +177,7 @@ This example shows the backend definition file configured with virtual storage p
 The following StorageClass definitions refer to the storage pools above. By using the `parameters.selector` field, you can specify for each StorageClass the virtual pool that is used to host a volume. The volume will have the aspects defined in the chosen virtual pool.
 
 // Start snippet: collapsible block (open on page load)
-.Expand example
+.Example
 [%collapsible]
 ====
 


### PR DESCRIPTION
Removed "Expand" from collapsible blocks headings to eliminate confusion on non-English repos where collapsible blocks are not yet supported. 