### PR TITLE
168: Correct limitVolumeSize

### DIFF
--- a/trident-use/ontap-nas-examples.adoc
+++ b/trident-use/ontap-nas-examples.adoc
@@ -55,7 +55,7 @@ For seamless MetroCluster switchover, you must specify an SVM management LIF. Th
 
 |`limitAggregateUsage` |Fail provisioning if usage is above this percentage. *Does not apply to Amazon FSx for ONTAP* |“” (not enforced by default)
 
-|`limitVolumeSize` |Fail provisioning if requested volume size is above this value for the economy driver. |“”  (not enforced by default)
+|`limitVolumeSize` |Fail provisioning if requested volume size is above this value. |“”  (not enforced by default)
 
 |`lunsPerFlexvol` |Maximum LUNs per Flexvol, must be in range [50, 200] |“100”
 

--- a/trident-use/ontap-san-examples.adoc
+++ b/trident-use/ontap-san-examples.adoc
@@ -61,7 +61,7 @@ For seamless MetroCluster switchover, you must specify an SVM management LIF. Th
 
 |`limitAggregateUsage` |Fail provisioning if usage is above this percentage. *Does not apply to Amazon FSx for ONTAP* |“” (not enforced by default)
 
-|`limitVolumeSize` |Fail provisioning if requested volume size is above this value for the economy driver. |“”  (not enforced by default)
+|`limitVolumeSize` |Fail provisioning if requested volume size is above this value. |“”  (not enforced by default)
 
 |`lunsPerFlexvol` |Maximum LUNs per Flexvol, must be in range [50, 200] |“100”
 


### PR DESCRIPTION
Remove "for the economy driver" for SAN and NAS

Fixes #168 