### PR TITLE
Slack to Discord migration

### DIFF
--- a/faq.adoc
+++ b/faq.adoc
@@ -111,7 +111,7 @@ Create an issue on https://github.com/NetApp/trident[Astra Trident Github^]. Mak
 
 === What happens if I have quick question on Astra Trident that I need clarification on? Is there a community or a forum?
 
-If you have any questions, issues, or requests, reach out to us through our link:https://discord.gg/NetApp[Discord channel^] or GitHub.
+If you have any questions, issues, or requests, reach out to us through our Astra link:https://discord.gg/NetApp[Discord channel^] or GitHub.
 
 === My storage system’s password has changed and Astra Trident no longer works, how do I recover?
 

--- a/faq.adoc
+++ b/faq.adoc
@@ -111,7 +111,7 @@ Create an issue on https://github.com/NetApp/trident[Astra Trident Github^]. Mak
 
 === What happens if I have quick question on Astra Trident that I need clarification on? Is there a community or a forum?
 
-If you have any questions, issues, or requests, reach out to us through our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^] or GitHub.
+If you have any questions, issues, or requests, reach out to us through our link:https://discord.gg/NetApp[Discord channel^] or GitHub.
 
 === My storage system’s password has changed and Astra Trident no longer works, how do I recover?
 

--- a/faq.adoc
+++ b/faq.adoc
@@ -103,7 +103,7 @@ You can create a support bundle by running `tridentctl logs -a`. In addition to 
 
 === What do I do if I need to raise a request for a new feature?
 
-Create an issue on https://github.com/NetApp/trident[Trident Github^] and mention *RFE* in the subject and description of the issue.
+Create an issue on https://github.com/NetApp/trident[Astra Trident Github^] and mention *RFE* in the subject and description of the issue.
 
 === Where do I raise a defect?
 
@@ -111,7 +111,7 @@ Create an issue on https://github.com/NetApp/trident[Astra Trident Github^]. Mak
 
 === What happens if I have quick question on Astra Trident that I need clarification on? Is there a community or a forum?
 
-If you have any questions, issues, or requests, reach out to us through our http://netapp.io/slack[Slack^] team or GitHub.
+If you have any questions, issues, or requests, reach out to us through our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^] or GitHub.
 
 === My storage system’s password has changed and Astra Trident no longer works, how do I recover?
 

--- a/get-help.adoc
+++ b/get-help.adoc
@@ -12,4 +12,4 @@ summary: NetApp provides support for Trident in a variety of ways. Extensive fre
 
 Astra Trident is an officially supported NetApp project. You can reach out to NetApp using any of the standard mechanisms and get the enterprise grade support that you need.
 
-There is also a vibrant public community of container users (including Astra Trident developers) on our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.
+There is also a vibrant public community of container users (including Astra Trident developers) on our link:https://discord.gg/NetApp[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.

--- a/get-help.adoc
+++ b/get-help.adoc
@@ -1,8 +1,8 @@
 ---
 sidebar: sidebar
 permalink: get-help.html
-keywords: get help, get support, knowledgebase, slack, phone, web, ticket, contact support, support ticket
-summary: NetApp provides support for Trident in a variety of ways. Extensive free self-support options are available 24x7, such as a Slack channel.
+keywords: get help, get support, knowledgebase, discord, phone, web, ticket, contact support, support ticket
+summary: NetApp provides support for Trident in a variety of ways. Extensive free self-support options are available 24x7, such as a Discord channel.
 ---
 
 = Support
@@ -12,4 +12,4 @@ summary: NetApp provides support for Trident in a variety of ways. Extensive fre
 
 Astra Trident is an officially supported NetApp project. You can reach out to NetApp using any of the standard mechanisms and get the enterprise grade support that you need.
 
-There is also a vibrant public community of container users (including Astra Trident developers) on the `containers` channel on http://netapp.io/slack[NetApp’s Slack work^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.
+There is also a vibrant public community of container users (including Astra Trident developers) on the `containers` channel on our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.

--- a/get-help.adoc
+++ b/get-help.adoc
@@ -12,4 +12,4 @@ summary: NetApp provides support for Trident in a variety of ways. Extensive fre
 
 Astra Trident is an officially supported NetApp project. You can reach out to NetApp using any of the standard mechanisms and get the enterprise grade support that you need.
 
-There is also a vibrant public community of container users (including Astra Trident developers) on our link:https://discord.gg/NetApp[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.
+There is also a vibrant public community of container users (including Astra Trident developers) on our Astra link:https://discord.gg/NetApp[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.

--- a/get-help.adoc
+++ b/get-help.adoc
@@ -12,4 +12,4 @@ summary: NetApp provides support for Trident in a variety of ways. Extensive fre
 
 Astra Trident is an officially supported NetApp project. You can reach out to NetApp using any of the standard mechanisms and get the enterprise grade support that you need.
 
-There is also a vibrant public community of container users (including Astra Trident developers) on the `containers` channel on our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.
+There is also a vibrant public community of container users (including Astra Trident developers) on our link:https://discord.com/channels/855068651522490400/999009138774380656[Discord channel^]. This is a great place to ask general questions about the project and discuss related topics with like-minded peers.

--- a/project.yml
+++ b/project.yml
@@ -106,5 +106,5 @@ homepage:
         - title: NetApp.io
           url: https://netapp.io/
         - title: Discord
-          url: https://discord.com/channels/855068651522490400/892881903638691850
+          url: https://discord.gg/NetApp
 

--- a/project.yml
+++ b/project.yml
@@ -105,6 +105,6 @@ homepage:
           url: https://cloud.netapp.com/kubernetes-hub
         - title: NetApp.io
           url: https://netapp.io/
-        - title: Slack
-          url: https://netapppub.slack.com/
+        - title: Discord
+          url: https://discord.com/channels/855068651522490400/892881903638691850
 

--- a/trident-use/project.yml
+++ b/trident-use/project.yml
@@ -89,4 +89,4 @@ homepage:
         - title: NetApp.io
           url: https://netapp.io/
         - title: Discord
-          url: https://discord.com/channels/855068651522490400/892881903638691850
+          url: https://discord.gg/NetApp

--- a/trident-use/project.yml
+++ b/trident-use/project.yml
@@ -88,5 +88,5 @@ homepage:
           url: https://cloud.netapp.com/kubernetes-hub
         - title: NetApp.io
           url: https://netapp.io/
-        - title: Slack
-          url: https://netapppub.slack.com/
+        - title: Discord
+          url: https://discord.com/channels/855068651522490400/892881903638691850


### PR DESCRIPTION
Updated Slack links to new Discord channel: https://discord.gg/NetApp