### PR TITLE
Added MCC GA line to release notes

### DIFF
--- a/trident-rn.adoc
+++ b/trident-rn.adoc
@@ -52,6 +52,8 @@ Use of non-multipathing configuration or use of `find_multipaths: yes` or `find_
 
 * Added link:https://docs.netapp.com/us-en/trident/trident-use/anf.html[support for SMB volumes on Windows nodes] through the `azure-netapp-files` storage driver.
 
+* Automatic MetroCluster switchover detection for ONTAP drivers is now generally available.
+
 === Deprecations
 
 * **Kubernetes:** Updated minimum supported Kubernetes to 1.20.


### PR DESCRIPTION
Added: Automatic MetroCluster switchover detection for ONTAP drivers is now generally available.