### PR TITLE
Issue 233: update iscsi chap info to indicate element os 127 doesnt require md5

### DIFF
--- a/trident-rn.adoc
+++ b/trident-rn.adoc
@@ -231,7 +231,7 @@ Known issues identify problems that might prevent you from using the product suc
 
 * When using Astra Trident over IPv6, you should specify `managementLIF` and `dataLIF` in the backend definition within square brackets. For example, ``[fd20:8b1e:b258:2000:f816:3eff:feec:0]``.
 
-* If using the `solidfire-san` driver with OpenShift 4.5, ensure that the underlying worker nodes use MD5 as the CHAP authentication algorithm.
+* If using the `solidfire-san` driver with OpenShift 4.5, ensure that the underlying worker nodes use MD5 as the CHAP authentication algorithm. Secure FIPS-compliant CHAP algorithms SHA1, SHA-256, and SHA3-256 are available with Element 12.7.
 
 == Find more information
 * https://github.com/NetApp/trident[Astra Trident GitHub^]

--- a/trident-use/worker-node-prep.adoc
+++ b/trident-use/worker-node-prep.adoc
@@ -57,7 +57,7 @@ NOTE: You should ensure that the NFS service is started up during boot time.
 Consider the following when using iSCSI volumes:
 
 * Each node in the Kubernetes cluster must have a unique IQN. *This is a necessary prerequisite*.
-* If using RHCOS version 4.5 or later, or other RHEL-compatible Linux distribution, with the `solidfire-san` driver, ensure that the CHAP authentication algorithm is set to MD5 in `/etc/iscsi/iscsid.conf`.
+* If using RHCOS version 4.5 or later, or other RHEL-compatible Linux distribution, with the `solidfire-san` driver and Element OS 12.5 or earlier, ensure that the CHAP authentication algorithm is set to MD5 in `/etc/iscsi/iscsid.conf`. Secure FIPS-compliant CHAP algorithms SHA1, SHA-256, and SHA3-256 are available with Element 12.7.
 +
 ----
 sudo sed -i 's/^\(node.session.auth.chap_algs\).*/\1 = MD5/' /etc/iscsi/iscsid.conf


### PR DESCRIPTION
Fixes #233 