### PR TITLE
Issue 260: Add excludepodsecuritypolicy note for Helm

### DIFF
--- a/trident-get-started/kubernetes-deploy-helm.adoc
+++ b/trident-get-started/kubernetes-deploy-helm.adoc
@@ -36,6 +36,8 @@ Review link:../trident-get-started/kubernetes-deploy.html[the installation overv
 
 In addition to the link:../trident-get-started/kubernetes-deploy.html#before-you-deploy[deployment prerequisites] you need link:https://v3.helm.sh/[Helm version 3^].
 
+WARNING: When installing Astra Trident on Kubernetes 1.26 or later, you must update values.yaml to set `excludePodSecurityPolicy` to `true` or pass the 
+
 .Steps
 
 . Add the Astra Trident Helm repository:

--- a/trident-get-started/kubernetes-deploy-helm.adoc
+++ b/trident-get-started/kubernetes-deploy-helm.adoc
@@ -36,8 +36,6 @@ Review link:../trident-get-started/kubernetes-deploy.html[the installation overv
 
 In addition to the link:../trident-get-started/kubernetes-deploy.html#before-you-deploy[deployment prerequisites] you need link:https://v3.helm.sh/[Helm version 3^].
 
-WARNING: When installing Astra Trident on Kubernetes 1.26 or later, you must update values.yaml to set `excludePodSecurityPolicy` to `true` or pass the 
-
 .Steps
 
 . Add the Astra Trident Helm repository:

--- a/trident-get-started/requirements.adoc
+++ b/trident-get-started/requirements.adoc
@@ -44,6 +44,8 @@ The Trident operator is supported with these releases:
 
 Astra Trident also works with a host of other fully-managed and self-managed Kubernetes offerings, including Google Kubernetes Engine (GKE), Amazon Elastic Kubernetes Services (EKS), Azure Kubernetes Service (AKS), Rancher, and VMWare Tanzu Portfolio.
 
+WARNING: Before upgrading a Kubernetes cluster from 1.24 to 1.25 or later that has Astra Trident installed, see link:../trident-managing-k8s/upgrade-operator.html#upgrade-a-helm-based-operator-installation[Upgrade a Helm-based operator installation].
+
 == Supported backends (storage)
 
 To use Astra Trident, you need one or more of the following supported backends:

--- a/trident-managing-k8s/upgrade-operator.adoc
+++ b/trident-managing-k8s/upgrade-operator.adoc
@@ -183,9 +183,11 @@ NOTE: The `trident-controller` and pod names reflect the naming convention intro
 
 Perform the following steps to upgrade a Helm-based operator installation.
 
+WARNING: When upgrading a Kubernetes cluster from 1.24 to 1.25 or later that has Astra Trident installed, you must update values.yaml to set `excludePodSecurityPolicy` to `true` or add `--set excludePodSecurityPolicy=true` to the `helm upgrade` command before you can upgrade the cluster.
+
 .Steps
 . Download the latest Astra Trident release.
-. Use the `helm upgrade` command where `trident-operator-23.01.0.tgz` reflects the version that you want to upgrade to:
+. Use the `helm upgrade` command where `trident-operator-23.01.0.tgz` reflects the version that you want to upgrade to.
 +
 ----
 helm upgrade <name> trident-operator-23.01.0.tgz

--- a/trident-rn.adoc
+++ b/trident-rn.adoc
@@ -244,6 +244,7 @@ WARNING: The v21.10.0 release has an issue that can put the Trident controller i
 
 Known issues identify problems that might prevent you from using the product successfully.
 
+* When upgrading a Kubernetes cluster from 1.24 to 1.25 or later that has Astra Trident installed, you must update values.yaml to set `excludePodSecurityPolicy` to `true` or add `--set excludePodSecurityPolicy=true` to the `helm upgrade` command before you can upgrade the cluster.
 * Astra Trident now enforces a blank `fsType` (`fsType=""`) for volumes that do not have the `fsType` specified in their StorageClass. When working with Kubernetes 1.17 or later, Trident supports providing a blank `fsType` for NFS volumes. For iSCSI volumes, you are required to set the `fsType` on your StorageClass when enforcing an `fsGroup` using a Security Context.
 
 * When using a backend across multiple Astra Trident instances, each backend configuration file should have a different `storagePrefix` value for ONTAP backends or use a different `TenantName` for SolidFire backends. Astra Trident cannot detect volumes that other instances of Astra Trident have created. Attempting to create an existing volume on either ONTAP or SolidFire backends succeeds, because Astra Trident treats volume creation as an idempotent operation. If `storagePrefix` or `TenantName` do not differ, there might be name collisions for volumes created on the same backend.


### PR DESCRIPTION
Added note about upgrading a Kubernetes cluster from 1.24 to 1.25 or later that has Astra Trident installed.