### PR TITLE
Issue 248: Remove dataLIF from SAN samples [Admin] 

### DIFF
--- a/trident-use/ontap-san-examples.adoc
+++ b/trident-use/ontap-san-examples.adoc
@@ -150,7 +150,6 @@ Here’s an example with defaults defined:
 version: 1
 storageDriverName: ontap-san
 managementLIF: 10.0.0.1
-dataLIF: 10.0.0.2
 svm: trident_svm
 username: admin
 password: password
@@ -199,7 +198,6 @@ version: 1
 storageDriverName: ontap-san
 backendName: DefaultSANBackend
 managementLIF: 10.0.0.1
-dataLIF: 10.0.0.3
 svm: svm_iscsi
 useCHAP: true
 chapInitiatorSecret: cl9qxIm36DKyawxy
@@ -220,7 +218,6 @@ This is a minimal backend configuration example. This basic configuration create
 version: 1
 storageDriverName: ontap-san
 managementLIF: 10.0.0.1
-dataLIF: 10.0.0.3
 svm: svm_iscsi
 labels:
   k8scluster: test-cluster-1
@@ -265,7 +262,6 @@ In this example, some of the storage pool sets their own `spaceReserve`, `spaceA
 version: 1
 storageDriverName: ontap-san
 managementLIF: 10.0.0.1
-dataLIF: 10.0.0.3
 svm: svm_iscsi
 useCHAP: true
 chapInitiatorSecret: cl9qxIm36DKyawxy

--- a/trident-use/ontap-san-prep.adoc
+++ b/trident-use/ontap-san-prep.adoc
@@ -45,7 +45,6 @@ version: 1
 backendName: ExampleBackend
 storageDriverName: ontap-san
 managementLIF: 10.0.0.1
-dataLIF: 10.0.0.2
 svm: svm_nfs
 username: vsadmin
 password: password
@@ -59,7 +58,6 @@ password: password
   "backendName": "ExampleBackend",
   "storageDriverName": "ontap-san",
   "managementLIF": "10.0.0.1",
-  "dataLIF": "10.0.0.2",
   "svm": "svm_nfs",
   "username": "vsadmin",
   "password": "password"
@@ -131,7 +129,6 @@ cat cert-backend.json
 "storageDriverName": "ontap-san",
 "backendName": "SanBackend",
 "managementLIF": "1.2.3.4",
-"dataLIF": "1.2.3.8",
 "svm": "vserver_test",
 "clientCertificate": "Faaaakkkkeeee...Vaaalllluuuueeee",
 "clientPrivateKey": "LS0tFaKE...0VaLuES0tLS0K",
@@ -158,7 +155,6 @@ cat cert-backend-updated.json
 "storageDriverName": "ontap-san",
 "backendName": "SanBackend",
 "managementLIF": "1.2.3.4",
-"dataLIF": "1.2.3.8",
 "svm": "vserver_test",
 "username": "vsadmin",
 "password": "password",


### PR DESCRIPTION
Remove `dataLIF` from SAN samples because it is not supported for iSCSI or is derived for other protocols.