### PR TITLE
Issue 315: Remove dupe namespaces

### DIFF
--- a/trident-use/backend_options.adoc
+++ b/trident-use/backend_options.adoc
@@ -166,7 +166,7 @@ tridentbackendconfig.trident.netapp.io/tbc-ontap-nas-backend created
 
 After the `TridentBackendConfig` has been created, its phase must be `Bound`. It should also reflect the same backend name and UUID as that of the existing backend.
 ----
-kubectl -n trident get tbc tbc-ontap-nas-backend -n trident
+kubectl get tbc tbc-ontap-nas-backend -n trident
 NAME                   BACKEND NAME          BACKEND UUID                           PHASE   STATUS
 tbc-ontap-nas-backend  ontap-nas-backend     52f2eb10-e4c6-4160-99fc-96b3be5ab5d7   Bound   Success
 


### PR DESCRIPTION
Removed namespace duplicate. Retained namespace at the end to maintain consistency with other samples.

`kubectl -n trident get tbc tbc-ontap-nas-backend -n trident` ==> `kubectl get tbc tbc-ontap-nas-backend -n trident`

Fixes #315 