### PR TITLE
Issue 312: Create PVC in same namespace as dataSource

### DIFF
--- a/trident-use/vol-snapshots.adoc
+++ b/trident-use/vol-snapshots.adoc
@@ -94,7 +94,7 @@ The `Snapshot Content Name` identifies the VolumeSnapshotContent object which se
 
 == Step 3: Create PVCs from VolumeSnapshots
 
-This example creates a PVC using a snapshot:
+This example creates a PVC using a snapshot. 
 
 ----
 cat pvc-from-snap.yaml
@@ -117,7 +117,10 @@ spec:
 
 `dataSource` shows that the PVC must be created using a VolumeSnapshot named `pvc1-snap` as the source of the data. This instructs Astra Trident to create a PVC from the snapshot. After the PVC is created, it can be attached to a pod and used just like any other PVC.
 
-NOTE: When deleting a Persistent Volume with associated snapshots, the corresponding Trident volume is updated to a “Deleting state”. For the Astra Trident volume to be deleted, the snapshots of the volume should be removed.
+WARNING: The clone must be created in the same backend as the source volume. 
+
+== Deleting a PV with snapshots
+When deleting a Persistent Volume with associated snapshots, the corresponding Trident volume is updated to a “Deleting state”. Remove the volume snapshots to delete the Astra Trident volume.
 
 == Deploying a volume snapshot controller
 

--- a/trident-use/vol-snapshots.adoc
+++ b/trident-use/vol-snapshots.adoc
@@ -117,7 +117,7 @@ spec:
 
 `dataSource` shows that the PVC must be created using a VolumeSnapshot named `pvc1-snap` as the source of the data. This instructs Astra Trident to create a PVC from the snapshot. After the PVC is created, it can be attached to a pod and used just like any other PVC.
 
-WARNING: The clone must be created in the same backend as the source volume. 
+WARNING: The PVC must be created in the same namespace as its `dataSource`. 
 
 == Deleting a PV with snapshots
 When deleting a Persistent Volume with associated snapshots, the corresponding Trident volume is updated to a “Deleting state”. Remove the volume snapshots to delete the Astra Trident volume.


### PR DESCRIPTION
Added warning that the PVC must be created in the same namespace as the dataSource. 