### PR TITLE
Issue 325: RWOP missing from ontap-nas-economy

### DIFF
--- a/trident-concepts/ontap-drivers.adoc
+++ b/trident-concepts/ontap-drivers.adoc
@@ -46,7 +46,7 @@ a|"", nfs
 |`ontap-nas-economy`
 a|NFS
 a|Filesystem
-a|RWO,ROX,RWX
+a|RWO, ROX, RWX, RWOP
 a|"", nfs
 
 |`ontap-nas-flexgroup`


### PR DESCRIPTION
Added RWOP to supported access modes for `ontap-nas-economy`.