### PR TITLE
Issue 347: Remove MetroCluster from FSx

### DIFF
--- a/trident-use/trident-fsx-examples.adoc
+++ b/trident-use/trident-fsx-examples.adoc
@@ -36,8 +36,6 @@ See the following table for the backend configuration options:
 |`managementLIF` 
 |IP address of a cluster or SVM management LIF 
 
-For seamless MetroCluster switchover, you must specify an SVM management LIF.
-
 A fully-qualified domain name (FQDN) can be specified.
 
 Can be set to use IPv6 addresses if Astra Trident was installed using the `--use-ipv6` flag. IPv6 addresses must be defined in square brackets, such as [28e8:d9fb:a825:b7bf:69a8:d02f:9e7b:3555].  


### PR DESCRIPTION
MetroCluster is not supported for FSx for ONTAP. 