### PR TITLE
Issue 364: Fix broken link

### DIFF
--- a/faq.adoc
+++ b/faq.adoc
@@ -130,7 +130,7 @@ NetApp supports upgrading Astra Trident from one major release to the next immed
 
 === Is it possible to downgrade Trident to a previous release?
 
-There are a number of factors to be evaluated if you want to downgrade. See link:https://docs.netapp.com/us-en/trident/trident-managing-k8s/downgrade-trident.html[the section on downgrading].
+If you need a fix for bugs observed after an upgrade, dependency issues, or an unsuccessful or incomplete upgrade, you should link:../trident-managing-k8s/uninstall-trident.html[uninstall Astra Trident] and reinstall the earlier version using the specific instructions for that version. This is the only recommended way to downgrade to an earlier version.
 
 == Manage backends and volumes
 


### PR DESCRIPTION
The downgrade process was updated to clarify that uninstalling and reinstalling Trident is the only recommended way to downgrade Trident. The link to the previous content was obsolete. This has been corrected. 