### PR TITLE
Issue 390: Command should not assume post 1.25

### DIFF
--- a/trident-managing-k8s/upgrade-operator.adoc
+++ b/trident-managing-k8s/upgrade-operator.adoc
@@ -37,13 +37,14 @@ Ensure you are using a Kubernetes cluster running link:../trident-get-started/re
 . Delete the Trident operator that was used to install the current Astra Trident instance. For example, if you are upgrading from 23.04, run the following command:
 +
 ----
-kubectl delete -f 23.04/trident-installer/deploy/<bundle-name.yaml> -n trident
+kubectl delete -f 23.04/trident-installer/deploy/<bundle.yaml> -n trident
 ----
 . If you customized your initial installation using `TridentOrchestrator` attributes, you can edit the `TridentOrchestrator` object to modify the installation parameters. This might include changes made to specify mirrored Trident and CSI image registries for offline mode, enable debug logs, or specify image pull secrets.
-. Install Astra Trident using the correct bundle YAML file for your environment and Astra Trident version. For example, if you are installing Astra Trident 23.07 for Kubernetes 1.27, run the following command:
+. Install Astra Trident using the correct bundle YAML file for your environment, where `<bundle.yaml>` is
+`bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. For example, if you are installing Astra Trident 23.07, run the following command:
 +
 ----
-kubectl create -f 23.07.1/trident-installer/deploy/bundle_post_1_25.yaml -n trident
+kubectl create -f 23.07.1/trident-installer/deploy/<bundle.yaml> -n trident
 ----
 
 == Upgrade a Helm installation

--- a/trident-managing-k8s/upgrade-operator.adoc
+++ b/trident-managing-k8s/upgrade-operator.adoc
@@ -41,7 +41,7 @@ kubectl delete -f 23.04/trident-installer/deploy/<bundle.yaml> -n trident
 ----
 . If you customized your initial installation using `TridentOrchestrator` attributes, you can edit the `TridentOrchestrator` object to modify the installation parameters. This might include changes made to specify mirrored Trident and CSI image registries for offline mode, enable debug logs, or specify image pull secrets.
 . Install Astra Trident using the correct bundle YAML file for your environment, where `<bundle.yaml>` is
-`bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. For example, if you are installing Astra Trident 23.07, run the following command:
+`bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. For example, if you are installing Astra Trident 23.07, run the following command:
 +
 ----
 kubectl create -f 23.07.1/trident-installer/deploy/<bundle.yaml> -n trident


### PR DESCRIPTION
Changed 

`kubectl create -f 23.07.1/trident-installer/deploy/bundle_post_1_25.yaml -n trident`

to

> Install Astra Trident using the correct bundle YAML file for your environment, where `<bundle.yaml>` is
> `bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. For example, if you are installing Astra Trident 23.07, run the following command:
> 
> `kubectl create -f 23.07.1/trident-installer/deploy/<bundle.yaml> -n trident`

