### PR TITLE
Issue 389: Added /deploy to cp kustomization

### DIFF
--- a/trident-install/kubernetes-deploy-operator-mirror.adoc
+++ b/trident-install/kubernetes-deploy-operator-mirror.adoc
@@ -100,7 +100,7 @@ kubectl apply -f deploy/namespace.yaml
 . Create the `kustomization.yaml` using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-cp kustomization_<bundle.yaml> deploy/kustomization.yaml
+cp deploy/kustomization_<bundle.yaml> deploy/kustomization.yaml
 ----
 
 . Compile the bundle using using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 

--- a/trident-install/kubernetes-deploy-operator-mirror.adoc
+++ b/trident-install/kubernetes-deploy-operator-mirror.adoc
@@ -97,23 +97,23 @@ The Astra Trident installer provides a bundle file that can be used to install t
 kubectl apply -f deploy/namespace.yaml
 ----
 * To deploy the operator in a namespace other than the `trident` namespace, update `serviceaccount.yaml`, `clusterrolebinding.yaml` and `operator.yaml` and generate your bundle file using the `kustomization.yaml`. 
-. Create the `kustomization.yaml` using the following command where _<bundle>_ is `bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. 
+. Create the `kustomization.yaml` using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-cp kustomization_<bundle>.yaml kustomization.yaml
+cp kustomization_<bundle.yaml> deploy/kustomization.yaml
 ----
 
-. Compile the bundle using using the following command where _<bundle>_ is `bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. 
+. Compile the bundle using using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-kubectl kustomize deploy/ > deploy/<bundle>.yaml
+kubectl kustomize deploy/ > deploy/<bundle.yaml>
 ----
 
 .Steps
 . Create the resources and deploy the operator:
 +
 ----
-kubectl kustomize deploy/ > deploy/<bundle>.yaml
+kubectl kustomize deploy/ > deploy/<bundle.yaml>
 ----
 
 . Verify the operator, deployment, and replicasets were created. 

--- a/trident-install/kubernetes-deploy-operator-mirror.adoc
+++ b/trident-install/kubernetes-deploy-operator-mirror.adoc
@@ -113,7 +113,7 @@ kubectl kustomize deploy/ > deploy/<bundle.yaml>
 . Create the resources and deploy the operator:
 +
 ----
-kubectl kustomize deploy/ > deploy/<bundle.yaml>
+kubectl create -f deploy/<bundle.yaml>
 ----
 
 . Verify the operator, deployment, and replicasets were created. 

--- a/trident-install/kubernetes-deploy-operator.adoc
+++ b/trident-install/kubernetes-deploy-operator.adoc
@@ -90,15 +90,15 @@ The Astra Trident installer provides a bundle file that can be used to install t
 kubectl apply -f deploy/namespace.yaml
 ----
 * To deploy the operator in a namespace other than the `trident` namespace, update `serviceaccount.yaml`, `clusterrolebinding.yaml` and `operator.yaml` and generate your bundle file using the `kustomization.yaml`. 
-. Create the `kustomization.yaml` using the following command where _<bundle>_ is `bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. 
+. Create the `kustomization.yaml` using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-cp kustomization_<bundle>.yaml kustomization.yaml
+cp kustomization_<bundle.yaml> deploy/kustomization.yaml
 ----
-. Compile the bundle using using the following command where _<bundle>_ is `bundle_pre_1_25` or `bundle_post_1_25` based on your Kubernetes version. 
+. Compile the bundle using using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-kubectl kustomize deploy/ > deploy/<bundle>.yaml
+kubectl kustomize deploy/ > deploy/<bundle.yaml>
 ----
 
 
@@ -107,7 +107,7 @@ kubectl kustomize deploy/ > deploy/<bundle>.yaml
 . Create the resources and deploy the operator:
 +
 ----
-kubectl create -f deploy/<bundle>.yaml
+kubectl create -f deploy/<bundle.yaml>
 ----
 . Verify the operator, deployment, and replicasets were created. 
 +

--- a/trident-install/kubernetes-deploy-operator.adoc
+++ b/trident-install/kubernetes-deploy-operator.adoc
@@ -93,7 +93,7 @@ kubectl apply -f deploy/namespace.yaml
 . Create the `kustomization.yaml` using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +
 ----
-cp kustomization_<bundle.yaml> deploy/kustomization.yaml
+cp deploy/kustomization_<bundle.yaml> deploy/kustomization.yaml
 ----
 . Compile the bundle using using the following command where _<bundle.yaml>_ is `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. 
 +

--- a/trident-managing-k8s/upgrade-operator.adoc
+++ b/trident-managing-k8s/upgrade-operator.adoc
@@ -40,7 +40,7 @@ Ensure you are using a Kubernetes cluster running link:../trident-get-started/re
 kubectl delete -f 23.04/trident-installer/deploy/<bundle.yaml> -n trident
 ----
 . If you customized your initial installation using `TridentOrchestrator` attributes, you can edit the `TridentOrchestrator` object to modify the installation parameters. This might include changes made to specify mirrored Trident and CSI image registries for offline mode, enable debug logs, or specify image pull secrets.
-. Install Astra Trident using the correct bundle YAML file for your environment, where `<bundle.yaml>` is
+. Install Astra Trident using the correct bundle YAML file for your environment, where _<bundle.yaml>_ is
 `bundle_pre_1_25.yaml` or `bundle_post_1_25.yaml` based on your Kubernetes version. For example, if you are installing Astra Trident 23.07, run the following command:
 +
 ----


### PR DESCRIPTION
- Changed `cp kustomization_<bundle>.yaml kustomization.yaml` to `cp kustomization_<bundle.yaml> deploy/kustomization.yaml`
- Updated references to `<bundle.yaml>` to be consistent across topics. 
- Added fix for https://github.com/NetAppDocs/trident/issues/388