### PR TITLE
Update vol-snapshots.adoc

### DIFF
--- a/trident-use/vol-snapshots.adoc
+++ b/trident-use/vol-snapshots.adoc
@@ -150,6 +150,9 @@ spec:
   driver: csi.trident.netapp.io
   source:
     snapshotHandle: pvc-f71223b5-23b9-4235-bbfe-e269ac7b84b0/import-snap-content # <import PV name or source PV name>/<volume-snapshot-content-name>
+  volumeSnapshotRef:
+    name: import-snap
+    namespace: default # Namespace of the VolumeSnapshot object which the content is bound to
 ----
 
 . *Cluster admin:* Create the `VolumeSnapshot` CR that references the `VolumeSnapshotContent` object. This requests access to use the `VolumeSnapshot` in a given namespace.


### PR DESCRIPTION
Hello,

While trying out volume import examples on a recent K8s version (1.28), `VolumeSnapshotContent` creation example returns the following error:

```
The VolumeSnapshotContent "import-snap-content" is invalid: spec.volumeSnapshotRef: Required value
```

Adding `volumeSnapshotRef` with both `name` and `namespace` values fixes it.