### PR TITLE
(fix) Change back what's new 26.02 to correct version 25.10

### DIFF
--- a/trident-rn.adoc
+++ b/trident-rn.adoc
@@ -90,7 +90,7 @@ Two workarounds are available:
 * Fixed snapshot and backup failures caused by resource filters that excluded persistent volumes.
 * Fixed incorrect PVC restoration in multi-namespace applications with identically named PVCs across namespaces, which could result in data loss.
 
-== What's new in 26.02
+== What's new in 25.10
 Learn what's new in Trident and Trident Protect, including enhancements, fixes, and deprecations.
 
 === Trident
@@ -108,7 +108,7 @@ Learn what's new in Trident and Trident Protect, including enhancements, fixes, 
 ** Added an option `--no-rename` when importing a volume to retain the original name but let Trident manage the volume's lifecycle. See link:https://docs.netapp.com/us-en/trident/trident-use/vol-import.html[Import volumes^].
 ** Trident deployment now runs at the system-cluster-critical priority class. 
 * Added an option for Trident controller to use host networking via helm, operator, and tridentctl (link:https://github.com/NetApp/trident/issues/858[Issue #858]).
-* Added manual QoS support to the ANF driver, making it production-ready in Trident 26.02; this experimental enhancement was introduced in Trident 25.06.
+* Added manual QoS support to the ANF driver, making it production-ready in Trident 25.10; this experimental enhancement was introduced in Trident 25.06.
 
 ==== Experimental Enhancements
 NOTE: Not for use in production environments.


### PR DESCRIPTION
Made a merge request to fix Issue - Misspelling the Changelog #848 
The "What's new 26.02" appears twice and "What's new 25.10" was gone after new version came out. Most likely from a replace of all "25.10" in all files after upgrade.