### PR TITLE
Fix typo in protocol names (FCP/NVMe)

### DIFF
--- a/trident-use/automatic-volume-expansion.adoc
+++ b/trident-use/automatic-volume-expansion.adoc
@@ -30,8 +30,8 @@ Before configuring automatic volume expansion, ensure that the following require
 * Supported ONTAP protocols:
 ** Network File System (NFS)
 ** Internet Small Computer Systems Interface (iSCSI)
-** Fibre Channel Protocol (NVMe)
-** Non-Volatile Memory Express over Fabrics (FCP)
+** Fibre Channel Protocol (FCP)
+** Non-Volatile Memory Express over Fabrics (NVMe)
 
 == Limitations
 
@@ -42,8 +42,8 @@ Before configuring automatic volume expansion, ensure that the following require
 * Supported protocols for automatic volume expansion:
 ** Network File System (NFS)
 ** Internet Small Computer Systems Interface (iSCSI)
-** Fibre Channel Protocol (NVMe)
-** Non-Volatile Memory Express over Fabrics (FCP)
+** Fibre Channel Protocol (FCP)
+** Non-Volatile Memory Express over Fabrics (NVMe)
 
 == Provision Volumes with Autogrow Policy
 


### PR DESCRIPTION
This PR fixes a typo in the automatic-volume-expansion.adoc file where the protocol names were incorrectly swapped. This addresses issue #854.